### PR TITLE
Add new century characters for 2023-01-01

### DIFF
--- a/.github/workflows/example_workflow_for_codecov.yaml
+++ b/.github/workflows/example_workflow_for_codecov.yaml
@@ -1,0 +1,24 @@
+on: ["push", "pull_request"]
+name: Example workflow for Codecov
+jobs:
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: php-actions/composer@v5
+      - uses: php-actions/phpunit@v3
+        with:
+          configuration: phpunit.xml.dist
+          php_extensions: xdebug
+          bootstrap: vendor/autoload.php
+          args: --coverage-clover=clover.xml -vvv
+        env:
+          XDEBUG_MODE: coverage
+
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v3
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: ./clover.xml
+          verbose: true

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 vendor/
 phpunit.xml
 *.lock
+.idea/

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This simple class validates social security numbers and provides methods for che
 
 ## Requirements
 
-- PHP >= 5.4
+- PHP >= 8.0
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ You can initialize the object in two ways:
 ```php
 <?php
 
-$hetu = devsmo\Hetu::create('041281-981T');
+$hetu = Devsmo\Hetu::create('041281-981T');
 
 if ( $hetu ) {
 	echo "It's valid";
@@ -49,7 +49,7 @@ Or if you want to catch possible errors:
 <?php
 
 try {
-	$hetu = new devsmo\Hetu('041281-981T');
+	$hetu = new Devsmo\Hetu('041281-981T');
 }
 catch (\InvalidArgumentException $e){
 	$msg = $e->getMessage();

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # php-hetu
 
+[![codecov](https://codecov.io/gh/SPLCompanyOy/php-hetu/branch/master/graph/badge.svg?token=5TWOBQSRJD)](https://codecov.io/gh/SPLCompanyOy/php-hetu)
+
 Finnish Social Security number validator.
 
 This simple class validates social security numbers and provides methods for checking birthdate, age and gender based on the 'hetu'.

--- a/composer.json
+++ b/composer.json
@@ -11,5 +11,8 @@
     },
     "autoload": {
         "classmap": ["src/"]
+    },
+    "require-dev": {
+        "phpunit/phpunit": "^9.5"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
     "homepage": "https://github.com/Devsmo/php-hetu",
     "license": "MIT",
     "require": {
-        "php": ">=5.4.0"
+        "php": ">=8.0"
     },
     "autoload": {
         "classmap": ["src/"]

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
     "type": "library",
     "description": "PHP Hetu validator. Hetu stands for Henkilötunnus aka Finnish Social Security Number",
     "keywords": [],
-    "homepage": "https://github.com/devsmo/php-hetu",
+    "homepage": "https://github.com/Devsmo/php-hetu",
     "license": "MIT",
     "require": {
         "php": ">=5.4.0"

--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,8 @@
     "homepage": "https://github.com/Devsmo/php-hetu",
     "license": "MIT",
     "require": {
-        "php": ">=8.0"
+        "php": ">=8.0",
+        "nesbot/carbon": "^2.58"
     },
     "autoload": {
         "classmap": ["src/"]

--- a/composer.json
+++ b/composer.json
@@ -6,8 +6,7 @@
     "homepage": "https://github.com/Devsmo/php-hetu",
     "license": "MIT",
     "require": {
-        "php": ">=8.0",
-        "nesbot/carbon": "^2.58"
+        "php": ">=8.0"
     },
     "autoload": {
         "classmap": ["src/"]

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -8,7 +8,6 @@
          convertWarningsToExceptions="true"
          processIsolation="false"
          stopOnFailure="false"
-         syntaxCheck="false"
          bootstrap="./tests/bootstrap.php"
         >
     <testsuites>
@@ -17,9 +16,9 @@
         </testsuite>
     </testsuites>
 
-    <filter>
-        <whitelist processUncoveredFilesFromWhitelist="true">
-            <directory>./src/</directory>
-        </whitelist>
-    </filter>
+    <coverage>
+        <include>
+            <directory suffix=".php">src</directory>
+        </include>
+    </coverage>
 </phpunit>

--- a/src/Exceptions/InvalidCenturyCharacterException.php
+++ b/src/Exceptions/InvalidCenturyCharacterException.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Splcompanyoy\Exceptions;
+namespace Devsmo\Exceptions;
 
 use InvalidArgumentException;
 

--- a/src/Exceptions/InvalidCenturyCharacterException.php
+++ b/src/Exceptions/InvalidCenturyCharacterException.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Splcompanyoy\Exceptions;
+
+use InvalidArgumentException;
+
+class InvalidCenturyCharacterException extends InvalidArgumentException
+{
+  
+}

--- a/src/Exceptions/InvalidControllerCharacterException.php
+++ b/src/Exceptions/InvalidControllerCharacterException.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Splcompanyoy\Exceptions;
+namespace Devsmo\Exceptions;
 
 use InvalidArgumentException;
 

--- a/src/Exceptions/InvalidControllerCharacterException.php
+++ b/src/Exceptions/InvalidControllerCharacterException.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Splcompanyoy\Exceptions;
+
+use InvalidArgumentException;
+
+class InvalidControllerCharacterException extends InvalidArgumentException
+{
+  
+}

--- a/src/Exceptions/InvalidDayException.php
+++ b/src/Exceptions/InvalidDayException.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Splcompanyoy\Exceptions;
+
+use InvalidArgumentException;
+
+class InvalidDayException extends InvalidArgumentException
+{
+  
+}

--- a/src/Exceptions/InvalidDayException.php
+++ b/src/Exceptions/InvalidDayException.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Splcompanyoy\Exceptions;
+namespace Devsmo\Exceptions;
 
 use InvalidArgumentException;
 

--- a/src/Exceptions/InvalidLenghtException.php
+++ b/src/Exceptions/InvalidLenghtException.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Splcompanyoy\Exceptions;
+namespace Devsmo\Exceptions;
 
 use InvalidArgumentException;
 

--- a/src/Exceptions/InvalidLenghtException.php
+++ b/src/Exceptions/InvalidLenghtException.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Splcompanyoy\Exceptions;
+
+use InvalidArgumentException;
+
+class InvalidLenghtException extends InvalidArgumentException
+{
+  
+}

--- a/src/Exceptions/InvalidMonthException.php
+++ b/src/Exceptions/InvalidMonthException.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Splcompanyoy\Exceptions;
+namespace Devsmo\Exceptions;
 
 use InvalidArgumentException;
 

--- a/src/Exceptions/InvalidMonthException.php
+++ b/src/Exceptions/InvalidMonthException.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Splcompanyoy\Exceptions;
+
+use InvalidArgumentException;
+
+class InvalidMonthException extends InvalidArgumentException
+{
+  
+}

--- a/src/Exceptions/InvalidYearException.php
+++ b/src/Exceptions/InvalidYearException.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Splcompanyoy\Exceptions;
+namespace Devsmo\Exceptions;
 
 use InvalidArgumentException;
 

--- a/src/Exceptions/InvalidYearException.php
+++ b/src/Exceptions/InvalidYearException.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Splcompanyoy\Exceptions;
+
+use InvalidArgumentException;
+
+class InvalidYearException extends InvalidArgumentException
+{
+  
+}

--- a/src/Hetu.php
+++ b/src/Hetu.php
@@ -17,7 +17,7 @@ class Hetu {
     public const FEMALE = 'female';
     public const MALE = 'male';
 
-	public $hetu = null;
+	public string $hetu;
 	public $parts = null;
 
     public Carbon $dateOfBirth;

--- a/src/Hetu.php
+++ b/src/Hetu.php
@@ -1,6 +1,13 @@
 <?php
 namespace devsmo;
 
+use Splcompanyoy\Exceptions\InvalidCenturyCharacterException;
+use Splcompanyoy\Exceptions\InvalidControllerCharacterException;
+use Splcompanyoy\Exceptions\InvalidDayException;
+use Splcompanyoy\Exceptions\InvalidLenghtException;
+use Splcompanyoy\Exceptions\InvalidMonthException;
+use Splcompanyoy\Exceptions\InvalidYearException;
+
 class Hetu {
 
 	public $hetu = null;
@@ -27,7 +34,7 @@ class Hetu {
 		$this->hetu = $hetu;
 
 		if ( strlen($this->hetu) != 11 ) {
-			throw new \InvalidArgumentException("A hetu is always 11 characters long");
+			throw new InvalidLenghtException();
 		}
 
 		// Split hetu into it's building blocks
@@ -40,23 +47,23 @@ class Hetu {
 		$this->parts->checksum = strtoupper(substr($hetu, 10, 1));
 
 		if ( $this->parts->dd < 1 || $this->parts->dd > 31 ) {
-			throw new \InvalidArgumentException("Invalid day of the month");
+			throw new InvalidDayException();
 		}
 		
 		if ( $this->parts->mm < 1 || $this->parts->mm > 12 ) {
-			throw new \InvalidArgumentException("Invalid month");
+			throw new InvalidMonthException();
 		}
 		
 		if ( !is_numeric($this->parts->yy) ) {
-			throw new \InvalidArgumentException("Invalid year");
+			throw new InvalidYearException();
 		}
 
 		if ( !$this->getCentury() ) {
-			throw new \InvalidArgumentException("Invalid century character");
+			throw new InvalidCenturyCharacterException();
 		}
 
 		if ( $this->getValidationKey() != $this->parts->checksum ) {
-			throw new \InvalidArgumentException("Invalid hetu, the control character is wrong");
+			throw new InvalidControllerCharacterException();
 		}
 	}
 	

--- a/src/Hetu.php
+++ b/src/Hetu.php
@@ -2,6 +2,8 @@
 
 namespace Devsmo;
 
+use Carbon\Carbon;
+use Carbon\CarbonInterface;
 use Devsmo\Exceptions\InvalidCenturyCharacterException;
 use Devsmo\Exceptions\InvalidControllerCharacterException;
 use Devsmo\Exceptions\InvalidDayException;
@@ -18,6 +20,7 @@ class Hetu {
 	public $hetu = null;
 	public $parts = null;
 
+    public Carbon $dateOfBirth;
 
 	/**
 	 * create()
@@ -70,6 +73,9 @@ class Hetu {
 		if ( $this->getValidationKey() != $this->parts->checksum ) {
 			throw new InvalidControllerCharacterException();
 		}
+
+
+        $this->dateOfBirth = Carbon::create(($this->getCentury()+(int)$this->parts->yy), $this->parts->mm, $this->parts->dd);
 	}
 	
 
@@ -91,24 +97,21 @@ class Hetu {
 	/** 
 	 * getDateStr
 	 * Get date string. 
-	 * @todo Should this be a date object instead?
 	 * @return String yyyy-mm-dd
 	 */
-	public function getDateStr() {
-		return ($this->getCentury()+$this->parts->yy) ."-". str_pad($this->parts->mm, 2, "0", STR_PAD_LEFT) ."-". str_pad($this->parts->dd, 2, "0", STR_PAD_LEFT) ;
+	public function getDateStr(): string {
+		return $this->dateOfBirth->format('Y-m-d');
 	}
 
-	/** 
-	 * getAge
-	 * Get the age of the person based on the hetu. 
-	 * @param String, A date formated YYYY-MM-DD
-	 * @return Int, age
-	 */
-	public function getAge($date='today') {
-		$birthday =new \DateTime($this->getDateStr());
-		$today = new \DateTime($date);
-
-		return $birthday->diff($today)->y;
+    /**
+     * @param CarbonInterface|null $date Optional date for comparison.
+     * @return int The person's age in years
+     */
+	public function getAge(?CarbonInterface $date): int {
+        if (is_null($date)) {
+            $date = Carbon::today()->toImmutable();
+        }
+		return $this->dateOfBirth->diff($date)->y;
 	}
 
 	/**

--- a/src/Hetu.php
+++ b/src/Hetu.php
@@ -107,7 +107,7 @@ class Hetu {
      * @param CarbonInterface|null $date Optional date for comparison.
      * @return int The person's age in years
      */
-	public function getAge(?CarbonInterface $date): int {
+	public function getAge(?CarbonInterface $date = null): int {
         if (is_null($date)) {
             $date = Carbon::today()->toImmutable();
         }

--- a/src/Hetu.php
+++ b/src/Hetu.php
@@ -12,6 +12,9 @@ use Devsmo\Exceptions\InvalidYearException;
 class Hetu {
 
 
+    public const FEMALE = 'female';
+    public const MALE = 'male';
+
 	public $hetu = null;
 	public $parts = null;
 
@@ -129,8 +132,8 @@ class Hetu {
 	 */
 	public function getGender() {
 		switch ( $this->parts->id & 1 ) {
-			case 0: return "female";
-			case 1: return "male";
+			case 0: return self::FEMALE;
+			case 1: return self::MALE;
 		}
 	}
 }

--- a/src/Hetu.php
+++ b/src/Hetu.php
@@ -22,6 +22,18 @@ class Hetu {
 
     public Carbon $dateOfBirth;
 
+    public const CENTURY_CODES_1800 = [
+        '+'
+    ];
+
+    public const CENTURY_CODES_1900 = [
+        '-', 'Y', 'X', 'W', 'V', 'U'
+    ];
+
+    public const CENTURY_CODES_2000 = [
+        'A', 'B', 'C', 'D', 'E', 'F'
+    ];
+
 	/**
 	 * create()
 	 * Shortcut for initializing the Hetu class
@@ -120,12 +132,16 @@ class Hetu {
 	 * @return Int, Century in four digit format
 	 */
 	public function getCentury() {
-		switch( $this->parts->century_code ) {
-			case '+': return 1800;
-			case '-': return 1900;
-			case 'A': return 2000;
-			default: return null;
-		}
+        if (in_array($this->parts->century_code, self::CENTURY_CODES_1800)){
+            return 1800;
+        }
+        if (in_array($this->parts->century_code, self::CENTURY_CODES_1900)){
+            return 1900;
+        }
+        if (in_array($this->parts->century_code, self::CENTURY_CODES_2000)){
+            return 2000;
+        }
+        return null;
 	}
 
 	/**

--- a/src/Hetu.php
+++ b/src/Hetu.php
@@ -1,14 +1,16 @@
 <?php
-namespace devsmo;
 
-use Splcompanyoy\Exceptions\InvalidCenturyCharacterException;
-use Splcompanyoy\Exceptions\InvalidControllerCharacterException;
-use Splcompanyoy\Exceptions\InvalidDayException;
-use Splcompanyoy\Exceptions\InvalidLenghtException;
-use Splcompanyoy\Exceptions\InvalidMonthException;
-use Splcompanyoy\Exceptions\InvalidYearException;
+namespace Devsmo;
+
+use Devsmo\Exceptions\InvalidCenturyCharacterException;
+use Devsmo\Exceptions\InvalidControllerCharacterException;
+use Devsmo\Exceptions\InvalidDayException;
+use Devsmo\Exceptions\InvalidLenghtException;
+use Devsmo\Exceptions\InvalidMonthException;
+use Devsmo\Exceptions\InvalidYearException;
 
 class Hetu {
+
 
 	public $hetu = null;
 	public $parts = null;

--- a/tests/HetuTest.php
+++ b/tests/HetuTest.php
@@ -1,6 +1,7 @@
 <?php
 
 use PHPUnit\Framework\TestCase;
+use Devsmo\Hetu;
 
 class HetuTest extends TestCase
 {
@@ -19,7 +20,7 @@ class HetuTest extends TestCase
 	 */
 	public function testValidity($hetu, $gender, $birthday, $age)
 	{
-		$instance = devsmo\Hetu::create($hetu);
+		$instance = Hetu::create($hetu);
 		$this->assertNotNull($instance);
 	}
 
@@ -28,7 +29,7 @@ class HetuTest extends TestCase
 	 */
 	public function testGender($hetu, $gender, $birthday, $age)
 	{
-		$instance = devsmo\Hetu::create($hetu);
+		$instance = Hetu::create($hetu);
 		$this->assertEquals($gender, $instance->getGender());
 	}
 
@@ -43,7 +44,7 @@ class HetuTest extends TestCase
 	 */
 	public function testBirthday($hetu, $gender, $birthday, $age)
 	{
-		$instance = devsmo\Hetu::create($hetu);
+		$instance = Hetu::create($hetu);
 		$this->assertEquals($birthday, $instance->getDateStr());
 	}
 
@@ -52,7 +53,7 @@ class HetuTest extends TestCase
 	 */
 	public function testAge($hetu, $gender, $birthday, $age)
 	{
-		$instance = devsmo\Hetu::create($hetu);
+		$instance = Hetu::create($hetu);
 		$this->assertEquals($age, $instance->getAge());
 	}
 
@@ -72,7 +73,7 @@ class HetuTest extends TestCase
 	 */
 	public function testInvalidHetu($hetu)
 	{
-		$instance = devsmo\Hetu::create($hetu);
+		$instance = Hetu::create($hetu);
 		$this->assertNull($instance);
 	}
 

--- a/tests/HetuTest.php
+++ b/tests/HetuTest.php
@@ -9,11 +9,32 @@ class HetuTest extends TestCase
 
 	public function validTestSet()
 	{
-		return array(
-			// Valid sets (all values are valid)
-			array('211097-9476', Hetu::MALE, '1997-10-21', 20),
-			array('210202A992N', Hetu::FEMALE, '2002-02-21', 15),
-		);
+		// Valid sets (all values are valid)
+		yield '211097-9476' => ['211097-9476', Hetu::MALE, '1997-10-21', 20];
+		yield '210202A992N' => ['210202A992N', Hetu::FEMALE, '2002-02-21', 15];
+		// https://dvv.fi/hetu-uudistus
+		yield '010594Y9032' => ['010594Y9032' , Hetu::MALE, '1994-05-01', 23]; // Antti - kuollut
+		yield '010594Y9021' => ['010594Y9021' , Hetu::FEMALE, '1994-05-01', 23]; // Ëìñî Úllãstiina
+		yield '020594X903P' => ['020594X903P' , Hetu::MALE, '1994-05-02', 23]; // Eppu
+		yield '020594X902N' => ['020594X902N' , Hetu::FEMALE, '1994-05-02', 23]; // Eppu
+		yield '030594W903B' => ['030594W903B' , Hetu::MALE, '1994-05-03', 23]; // Eikka
+		yield '030694W9024' => ['030694W9024' , Hetu::FEMALE, '1994-06-03', 23]; // Erika
+		yield '040594V9030' => ['040594V9030' , Hetu::MALE, '1994-05-04', 23]; // Arska
+		yield '040594V902Y' => ['040594V902Y' , Hetu::FEMALE, '1994-05-04', 23]; // Pike
+		yield '050594U903M' => ['050594U903M' , Hetu::MALE, '1994-05-05', 23]; // Luca
+		yield '050594U902L' => ['050594U902L' , Hetu::FEMALE, '1994-05-05', 23]; // Siru
+		yield '010516B903X' => ['010516B903X' , Hetu::MALE, '2016-05-01', 1]; // Elias
+		yield '010516B902W' => ['010516B902W' , Hetu::FEMALE, '2016-05-01', 1]; // Siiri
+		yield '020516C903K' => ['020516C903K' , Hetu::MALE, '2016-05-02', 1]; // Erkki
+		yield '020516C902J' => ['020516C902J' , Hetu::FEMALE, '2016-05-02', 1]; // Elina
+		yield '030516D9037' => ['030516D9037' , Hetu::MALE, '2016-05-03', 1]; // Antti
+		yield '030516D9026' => ['030516D9026' , Hetu::FEMALE, '2016-05-03', 1]; // Saimi
+		yield '010501E9032' => ['010501E9032' , Hetu::MALE, '2001-05-01', 16]; // Jean
+		yield '020502E902X' => ['020502E902X' , Hetu::FEMALE, '2002-05-02', 15]; // Susanna
+		yield '020503F9037' => ['020503F9037' , Hetu::MALE, '2003-05-02', 14]; // Hannes
+		yield '020504A902E' => ['020504A902E' , Hetu::FEMALE, '2004-05-02', 13]; // (passiivi)
+		yield '020504B904H' => ['020504B904H' , Hetu::FEMALE, '2004-05-02', 13]; // Anne
+		
 	}
 	
 	/**
@@ -36,12 +57,6 @@ class HetuTest extends TestCase
 
 	/**
 	 * @dataProvider validTestSet
-
-
-
-
-
-
 	 */
 	public function testBirthday($hetu, $gender, $birthday, $age)
 	{
@@ -62,7 +77,7 @@ class HetuTest extends TestCase
 	public function invalidTestSet()
 	{
 		return array(
-			// Valid sets (all values are valid)
+			// Valid sets (none of the values are valid)
 			array('211096-9476'),
 			array('010202-992N'),
 			array('210202-992Nsd'),

--- a/tests/HetuTest.php
+++ b/tests/HetuTest.php
@@ -1,5 +1,6 @@
 <?php
 
+use Carbon\Carbon;
 use PHPUnit\Framework\TestCase;
 use Devsmo\Hetu;
 
@@ -54,7 +55,7 @@ class HetuTest extends TestCase
 	public function testAge($hetu, $gender, $birthday, $age)
 	{
 		$instance = Hetu::create($hetu);
-		$this->assertEquals($age, $instance->getAge());
+		$this->assertEquals($age, $instance->getAge(Carbon::parse('2018-02-02')));
 	}
 
 

--- a/tests/HetuTest.php
+++ b/tests/HetuTest.php
@@ -10,8 +10,8 @@ class HetuTest extends TestCase
 	{
 		return array(
 			// Valid sets (all values are valid)
-			array('211097-9476', 'male', '1997-10-21', 20),
-			array('210202A992N', 'female', '2002-02-21', 15),
+			array('211097-9476', Hetu::MALE, '1997-10-21', 20),
+			array('210202A992N', Hetu::FEMALE, '2002-02-21', 15),
 		);
 	}
 	

--- a/tests/HetuTest.php
+++ b/tests/HetuTest.php
@@ -1,14 +1,13 @@
 <?php
 
-use Carbon\Carbon;
 use PHPUnit\Framework\TestCase;
 use Devsmo\Hetu;
 
 class HetuTest extends TestCase
 {
 
-	public function validTestSet()
-	{
+	public function validTestSet(): ?\Generator
+    {
 		// Valid sets (all values are valid)
 		yield '211097-9476' => ['211097-9476', Hetu::MALE, '1997-10-21', 20];
 		yield '210202A992N' => ['210202A992N', Hetu::FEMALE, '2002-02-21', 15];
@@ -40,8 +39,8 @@ class HetuTest extends TestCase
 	/**
 	 * @dataProvider validTestSet
 	 */
-	public function testValidity($hetu, $gender, $birthday, $age)
-	{
+	public function testValidity($hetu, $gender, $birthday, $age): void
+    {
 		$instance = Hetu::create($hetu);
 		$this->assertNotNull($instance);
 	}
@@ -49,8 +48,8 @@ class HetuTest extends TestCase
 	/**
 	 * @dataProvider validTestSet
 	 */
-	public function testGender($hetu, $gender, $birthday, $age)
-	{
+	public function testGender($hetu, $gender, $birthday, $age): void
+    {
 		$instance = Hetu::create($hetu);
 		$this->assertEquals($gender, $instance->getGender());
 	}
@@ -58,8 +57,8 @@ class HetuTest extends TestCase
 	/**
 	 * @dataProvider validTestSet
 	 */
-	public function testBirthday($hetu, $gender, $birthday, $age)
-	{
+	public function testBirthday($hetu, $gender, $birthday, $age): void
+    {
 		$instance = Hetu::create($hetu);
 		$this->assertEquals($birthday, $instance->getDateStr());
 	}
@@ -67,15 +66,15 @@ class HetuTest extends TestCase
 	/**
 	 * @dataProvider validTestSet
 	 */
-	public function testAge($hetu, $gender, $birthday, $age)
-	{
+	public function testAge($hetu, $gender, $birthday, $age): void
+    {
 		$instance = Hetu::create($hetu);
-		$this->assertEquals($age, $instance->getAge(Carbon::parse('2018-02-02')));
+		$this->assertEquals($age, $instance->getAge(DateTimeImmutable::createFromFormat('Y-m-d','2018-02-02')));
 	}
 
 
-	public function invalidTestSet()
-	{
+	public function invalidTestSet(): array
+    {
 		return array(
 			// Valid sets (none of the values are valid)
 			array('211096-9476'),
@@ -87,8 +86,8 @@ class HetuTest extends TestCase
 	/**
 	 * @dataProvider invalidTestSet
 	 */
-	public function testInvalidHetu($hetu)
-	{
+	public function testInvalidHetu($hetu): void
+    {
 		$instance = Hetu::create($hetu);
 		$this->assertNull($instance);
 	}


### PR DESCRIPTION
# What

The Finnish SSN is receiving an update on the first of January 2023. See  for reference. This PR aims to solve the upcoming update.

[Lausuntopalvelu: Henkilötunnusjärjestelmän uudistamista koskevat säädös- ja muut ehdotukset](https://www.lausuntopalvelu.fi/FI/Proposal/Participation?proposalId=ec6f0f8f-0c33-48e7-8dfb-7b2505565988)

[Valtioneuvoston asetus VM/2022/124](https://vm.fi/paatos?decisionId=0900908f807c5f3c)

[DVV: Henkilötunnuksen uudistaminen](https://dvv.fi/hetu-uudistus)

# Changes made

* Added new century characters
* Added new testcases from DVV
* Require PHPUnit as development dependency
* Some developer quality of work changes
* * .gitignore to support PHPStorm
* * Separate exceptions for each parsing failure
* * Gender strings as constants
* * Coverage and upload it to coverage.io 


I initially implemented some of the source code to use Carbon but ultimately opted not to require it as this is a library.

I chose to upgrade the package to PHP8.0 for arbitrary reasons and this can be debated upon.